### PR TITLE
Use Connection:close when provider debug set to true.

### DIFF
--- a/src/main/java/org/dasein/cloud/aws/compute/EC2Method.java
+++ b/src/main/java/org/dasein/cloud/aws/compute/EC2Method.java
@@ -638,6 +638,9 @@ public class EC2Method {
 
             attempts++;
             post.addHeader("Content-Type", "application/x-www-form-urlencoded; charset=utf-8");
+            if ( provider.isDebug() ) {
+                post.addHeader("Connection", "close");
+            }
 
             List<NameValuePair> params = new ArrayList<NameValuePair>();
 


### PR DESCRIPTION
Trying to combat eventual consistency or caching issues during test suite run.

https://github.com/TheWeatherCompany/grid-api/issues/1070
